### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     name: Run all tests (unit + integration)
     runs-on: ubuntu-24.04
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/jainds/rag-demos/security/code-scanning/1](https://github.com/jainds/rag-demos/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the job level for the `test` job. Since the `test` job only needs to read repository contents (e.g., to install dependencies and run tests), we will set `contents: read` as the minimal required permission. This ensures that the job does not have unnecessary write access to the repository or other resources.

The `permissions` block will be added directly under the `test` job definition, ensuring it applies only to this job and does not affect other jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
